### PR TITLE
BREAKING: EEPROM Bug

### DIFF
--- a/firmware/STM32 Drivers/AT24C04C/Drivers/AT24C04C/Src/stm32f1xx_at24c04c.c
+++ b/firmware/STM32 Drivers/AT24C04C/Drivers/AT24C04C/Src/stm32f1xx_at24c04c.c
@@ -100,6 +100,8 @@ AT24C04C_StatusTypeDef AT24C04C_ReadData(AT24C04C_HandleTypeDef *hat24c04c, uint
 
     uint16_t I2C_Status = __mem_read(hat24c04c, address, buffer, len_bytes);
 
+    hat24c04c->State = AT24C04C_STATE_READY;
+
     if (I2C_Status == HAL_I2C_ERROR_TIMEOUT)
     {
         return AT24C04C_TIMEOUT;
@@ -108,8 +110,6 @@ AT24C04C_StatusTypeDef AT24C04C_ReadData(AT24C04C_HandleTypeDef *hat24c04c, uint
     {
         return AT24C04C_ERROR;
     }
-
-    hat24c04c->State = AT24C04C_STATE_READY;
 
     return AT24C04C_OK;
 }
@@ -143,6 +143,8 @@ AT24C04C_StatusTypeDef AT24C04C_WriteData(AT24C04C_HandleTypeDef *hat24c04c, uin
 
    uint16_t I2C_Status = __mem_write(hat24c04c, address, data, len_bytes);
 
+   hat24c04c->State = AT24C04C_STATE_READY;
+
     if (I2C_Status == HAL_I2C_ERROR_TIMEOUT)
     {
         return AT24C04C_TIMEOUT;
@@ -151,8 +153,6 @@ AT24C04C_StatusTypeDef AT24C04C_WriteData(AT24C04C_HandleTypeDef *hat24c04c, uin
     {
         return AT24C04C_ERROR;
     }
-
-    hat24c04c->State = AT24C04C_STATE_READY;
 
     return AT24C04C_OK;
 }


### PR DESCRIPTION
When using the Read/Write command for the AT24C04C driver, if an I2c timeout occurs, the driver will break. 

The driver is set to the busy state before completing a memory read/write. In the event that the bus times out (maybe the bus is not initialized, or there's another item using the bus for the entire timeout duration), the function returns BEFORE the driver is returned to the ready state. 

Any subsequent calls to the driver will immediately exit as the driver is in the busy state. 

While this isn't used in RAD or VIPER firmware, I wanted to address it while I can. 

I have moved up where the driver sets the ready state, so that the driver is always ready before any returns. 

We don't do these checks in read/write pages, but at least those aren't breaking rn