### PR TITLE
Fix Rover Dimensions in Kinematics Model + Drive Namespacing

### DIFF
--- a/ros_ws/src/bringup_py/launch/drivetrain.launch.py
+++ b/ros_ws/src/bringup_py/launch/drivetrain.launch.py
@@ -65,6 +65,7 @@ def generate_launch_description():
         package="drive",
         executable="drive_controller.py",
         name="drive_controller",
+        namespace="drive",
         parameters=[{
             "drive_mode": drive_mode
         }]
@@ -73,13 +74,15 @@ def generate_launch_description():
     odom_controller_node = Node(
         package="drive",
         executable="drive_modules_odom.py",
-        name="drive_modules_odom"
+        name="drive_modules_odom",
+        namespace="drive",
     )
 
     vesc_controller_node = Node(
         package="drive",
         executable="vesc_controller.py",
         name="vesc_controller",
+        namespace="drive",
         parameters=[{
             "can_rate": can_rate,
             "wait_until_positioned": wait_until_positioned 
@@ -92,6 +95,7 @@ def generate_launch_description():
         package="rad_control",
         executable="rad_drive_controller",
         name="rad_drive_controller",
+        namespace="drive",
         parameters=[{
             "can_rate": can_rate
         }]
@@ -101,6 +105,7 @@ def generate_launch_description():
         package="rad_control",
         executable="rad_calibration_init",
         name="rad_calibration_init",
+        namespace="drive",
         condition=LaunchConfigurationEquals(
                 "drive_mode",
                 "SWERVE_DRIVE"
@@ -111,6 +116,7 @@ def generate_launch_description():
         package="spidercan",
         executable="writer.py",
         name="writer",
+        namespace="drive",
         parameters=[{
             "channel": can_channel
         }]
@@ -120,6 +126,7 @@ def generate_launch_description():
         package="rad_control",
         executable="rover_steer_pos",
         name="steer_node",
+        namespace="drive",
         condition=LaunchConfigurationEquals(
             "drive_mode",
             "TANK_STEER_HYBRID"

--- a/ros_ws/src/bringup_py/launch/drivetrain.launch.py
+++ b/ros_ws/src/bringup_py/launch/drivetrain.launch.py
@@ -10,10 +10,10 @@ from launch.substitutions import LaunchConfiguration
 from launch.conditions import IfCondition, LaunchConfigurationEquals
 
 rad_status_to_id = {
-    "/front_right/rad_status": 0x11,
-    "/front_left/rad_status": 0x12,
-    "/rear_left/rad_status": 0x13,
-    "/rear_right/rad_status": 0x14
+    "/drive/front_right/rad_status": 0x11,
+    "/drive/front_left/rad_status": 0x12,
+    "/drive/rear_left/rad_status": 0x13,
+    "/drive/rear_right/rad_status": 0x14
 }
 
 def generate_launch_description():
@@ -129,7 +129,8 @@ def generate_launch_description():
         name="writer",
         namespace="drive",
         parameters=[{
-            "channel": can_channel
+            "channel": can_channel,
+            "topic": "/can/can_out"
         }]
     )
 

--- a/ros_ws/src/drive/drive/drive_controller.py
+++ b/ros_ws/src/drive/drive/drive_controller.py
@@ -29,15 +29,17 @@ class Drive:
         pass
 
 class SwerveDrive(Drive):
+    WIDTH = 1.0
+    LENGTH = 0.625
     def __init__(self, pub_odom: Publisher, pub_modules: Publisher) -> None:
         self.pub_odom = pub_odom
         self.pub_modules = pub_modules
         ## 0.54, 0.85, half: 0.27, 0.42
         modules = [
-            DriveModule("front_left", (-0.27, 0.42), 1.0, pi),
-            DriveModule("front_right", (0.27, 0.42), 1.0, pi),
-            DriveModule("rear_left", (-0.27, -0.42), 1.0, pi),
-            DriveModule("rear_right", (0.27, -0.42), 1.0, pi)
+            DriveModule("front_left", (-self.WIDTH / 2.0, self.LENGTH / 2.0), 1.0, pi),
+            DriveModule("front_right", (self.WIDTH / 2.0, self.LENGTH / 2.0), 1.0, pi),
+            DriveModule("rear_left", (-self.WIDTH / 2.0, -self.LENGTH / 2.0), 1.0, pi),
+            DriveModule("rear_right", (self.WIDTH / 2.0, -self.LENGTH / 2.0), 1.0, pi)
         ]
         self.model = SteeringModel(modules)
     

--- a/ros_ws/src/drive/drive/drive_controller.py
+++ b/ros_ws/src/drive/drive/drive_controller.py
@@ -29,17 +29,17 @@ class Drive:
         pass
 
 class SwerveDrive(Drive):
-    WIDTH = 1.0
-    LENGTH = 0.625
+    LENGTH = 1.0
+    WIDTH = 0.625
     def __init__(self, pub_odom: Publisher, pub_modules: Publisher) -> None:
         self.pub_odom = pub_odom
         self.pub_modules = pub_modules
         ## 0.54, 0.85, half: 0.27, 0.42
         modules = [
-            DriveModule("front_left", (-self.WIDTH / 2.0, self.LENGTH / 2.0), 1.0, pi),
-            DriveModule("front_right", (self.WIDTH / 2.0, self.LENGTH / 2.0), 1.0, pi),
-            DriveModule("rear_left", (-self.WIDTH / 2.0, -self.LENGTH / 2.0), 1.0, pi),
-            DriveModule("rear_right", (self.WIDTH / 2.0, -self.LENGTH / 2.0), 1.0, pi)
+            DriveModule("front_left", (-self.LENGTH / 2.0, self.WIDTH / 2.0), 1.0, pi),
+            DriveModule("front_right", (self.LENGTH / 2.0, self.WIDTH / 2.0), 1.0, pi),
+            DriveModule("rear_left", (-self.LENGTH / 2.0, -self.WIDTH / 2.0), 1.0, pi),
+            DriveModule("rear_right", (self.LENGTH / 2.0, -self.WIDTH / 2.0), 1.0, pi)
         ]
         self.model = SteeringModel(modules)
     

--- a/ros_ws/src/drive/drive/drive_controller.py
+++ b/ros_ws/src/drive/drive/drive_controller.py
@@ -115,19 +115,19 @@ class DriveController(Node):
             self.get_parameter("drive_mode").get_parameter_value().string_value
         ]
 
-        self.publisher_odom = self.create_publisher(Odometry, "/odom", 10)
-        self.publisher_modules_command = self.create_publisher(SwerveModulesList, "/modules_command", 10)
+        self.publisher_odom = self.create_publisher(Odometry, "/drive/odom", 10)
+        self.publisher_modules_command = self.create_publisher(SwerveModulesList, "/drive/modules_command", 10)
         self.drive = self.getDrive()
 
         self.subscription = self.create_subscription(
             SwerveModulesList,
-            "/drive_modules",
+            "/drive/drive_modules",
             self.callback,
             10,
         )
         self.subscription_cmd_vel = self.create_subscription(
             Twist,
-            "/cmd_vel_repeat",
+            "/drive/cmd_vel_repeat",
             self.drive.publishModulesCommand,
             10,
         )

--- a/ros_ws/src/drive/drive/drive_modules_odom.py
+++ b/ros_ws/src/drive/drive/drive_modules_odom.py
@@ -31,38 +31,38 @@ class DriveModulesOdom(Node):
 
         self.sub_fr_status = self.create_subscription(
             RadStatus, 
-            "/front_right/rad_status",
+            "/drive/front_right/rad_status",
             self._fr_rad_callback, 10)
         self.sub_fl_status = self.create_subscription(
             RadStatus, 
-            "/front_left/rad_status",
+            "/drive/front_left/rad_status",
             self._fl_rad_callback, 10)
         self.sub_br_status = self.create_subscription(
             RadStatus, 
-            "/rear_right/rad_status",
+            "/drive/rear_right/rad_status",
             self._br_rad_callback, 10)
         self.sub_bl_status = self.create_subscription(
             RadStatus, 
-            "/rear_left/rad_status",
+            "/drive/rear_left/rad_status",
             self._bl_rad_callback, 10)
         
         self.sub_fr_vstatus = self.create_subscription(
             Int32, 
-            "/front_right/vesc_rpm",
+            "/drive/front_right/vesc_rpm",
             self._fr_vesc_callback, 10)
         self.sub_fl_vstatus = self.create_subscription(
             Int32, 
-            "/front_left/vesc_rpm",
+            "/drive/front_left/vesc_rpm",
             self._fl_vesc_callback, 10)
         self.sub_br_vstatus = self.create_subscription(
             Int32, 
-            "/rear_right/vesc_rpm",
+            "/drive/rear_right/vesc_rpm",
             self._br_vesc_callback, 10)
         self.sub_bl_vstatus = self.create_subscription(
             Int32, 
-            "/rear_left/vesc_rpm",
+            "/drive/rear_left/vesc_rpm",
             self._bl_vesc_callback, 10)
-        self.odom_pub = self.create_publisher(SwerveModulesList, "/drive_modules", 10)
+        self.odom_pub = self.create_publisher(SwerveModulesList, "/drive/drive_modules", 10)
         self.timer = self.create_timer(
             1.0 / (self.get_parameter("odom_rate").get_parameter_value().integer_value),
             self._timer_callback

--- a/ros_ws/src/drive/drive/heartbeat.py
+++ b/ros_ws/src/drive/drive/heartbeat.py
@@ -34,9 +34,9 @@ class HeartBeatNode(Node):
         self.vel_msg = Twist()
         self.pulse_msg = SwerveModulePulse()
 
-        self.pub_vel = self.create_publisher(Twist, "/cmd_vel_repeat", 10)
+        self.pub_vel = self.create_publisher(Twist, "/drive/cmd_vel_repeat", 10)
         self.sub_vel = self.create_subscription(
-            Twist, "/cmd_vel", 
+            Twist, "/drive/cmd_vel", 
             self._vel_callback,
             10
         )
@@ -47,11 +47,11 @@ class HeartBeatNode(Node):
 
         if (self.mode == DriveMode.TANK_STEER_HYBRID):
             self.sub_pulses = self.create_subscription(
-                SwerveModulePulse, "/rad_pulses",
+                SwerveModulePulse, "/drive/rad_pulses",
                 self._pulse_callback,
                 10
             )
-            self.pub_pulse = self.create_publisher(SwerveModulePulse, "/rad_pulses_repeat", 10)
+            self.pub_pulse = self.create_publisher(SwerveModulePulse, "/drive/rad_pulses_repeat", 10)
             self.timer_pulse = self.create_timer(
                 1 / self.hz,
                 (lambda: self.pub_pulse.publish(self.pulse_msg))

--- a/ros_ws/src/drive/drive/keyboard_drive.py
+++ b/ros_ws/src/drive/drive/keyboard_drive.py
@@ -18,7 +18,7 @@ def getch():  # this function is used to get key input from user in the terminal
 def main():
     rclpy.init(args=None)
     node = Node("keyboard_controller")
-    publisher = node.create_publisher(Twist, "/cmd_vel", 10)
+    publisher = node.create_publisher(Twist, "/drive/cmd_vel", 10)
     vel_msg = Twist()
 
     print(

--- a/ros_ws/src/drive/drive/sim_command_converter.py
+++ b/ros_ws/src/drive/drive/sim_command_converter.py
@@ -23,7 +23,7 @@ class SimCommandConverter(Node):
         )
         self.subscription = self.create_subscription(
             SwerveModulesList,
-            "/modules_command",
+            "/drive/modules_command",
             self.callback,
             10,
         )

--- a/ros_ws/src/drive/drive/vesc_controller.py
+++ b/ros_ws/src/drive/drive/vesc_controller.py
@@ -14,11 +14,11 @@ class VescController(Node):
         super().__init__("vesc_controller")
         self.sub = self.create_subscription(
             SwerveModulesList, 
-            "/modules_command",
+            "/drive/modules_command",
             self._callback, 10)
         self.sub_odom = self.create_subscription(
             SwerveModulesList, 
-            "/drive_modules",
+            "/drive/drive_modules",
             self._odom_callback, 10)
 
         self.declare_parameter(

--- a/ros_ws/src/drive/drive/xbox_drive.py
+++ b/ros_ws/src/drive/drive/xbox_drive.py
@@ -100,12 +100,12 @@ class XboxDriveController(Node):
             self.get_parameter("drive_mode").get_parameter_value().string_value
         ]
         
-        self.pub_cmd_vel = self.create_publisher(Twist, "/cmd_vel", 10)
+        self.pub_cmd_vel = self.create_publisher(Twist, "/drive/cmd_vel", 10)
 
         if (self.mode == DriveMode.SWERVE_DRIVE):
             self.xbox_drive = XboxSwerveDrive(self.pub_cmd_vel)
         elif (self.mode == DriveMode.TANK_STEER_HYBRID):
-            self.pub = self.create_publisher(SwerveModulePulse, "/rad_pulses", 10)
+            self.pub = self.create_publisher(SwerveModulePulse, "/drive/rad_pulses", 10)
             self.xbox_drive = XboxTankSteerDrive(self.pub_cmd_vel, self.pub)
 
         self.sub = self.create_subscription(

--- a/ros_ws/src/drive/launch/vesc_status.launch.py
+++ b/ros_ws/src/drive/launch/vesc_status.launch.py
@@ -6,6 +6,7 @@ def generate_launch_description():
         package="spidercan",
         executable="reader.py",
         name="vesc_reader",
+        namespace="drive",
         parameters=[{
             "topic": "/can/vesc_can_in",
             "channel": "can0",
@@ -18,6 +19,7 @@ def generate_launch_description():
         package="drive",
         executable="vesc_status.py",
         name="vesc1_status_node",
+        namespace="drive",
         parameters=[{
             "status": "STATUS_1",
             "motor": "BACK_RIGHT",
@@ -31,6 +33,7 @@ def generate_launch_description():
         package="drive",
         executable="vesc_status.py",
         name="vesc2_status_node",
+        namespace="drive",
         parameters=[{
             "status": "STATUS_1",
             "motor": "FRONT_RIGHT",
@@ -44,6 +47,7 @@ def generate_launch_description():
         package="drive",
         executable="vesc_status.py",
         name="vesc4_status_node",
+        namespace="drive",
         parameters=[{
             "status": "STATUS_1",
             "motor": "FRONT_LEFT",
@@ -57,6 +61,7 @@ def generate_launch_description():
         package="drive",
         executable="vesc_status.py",
         name="vesc3_status_node",
+        namespace="drive",
         parameters=[{
             "status": "STATUS_1",
             "motor": "BACK_LEFT",

--- a/ros_ws/src/drive/launch/vesc_status.launch.py
+++ b/ros_ws/src/drive/launch/vesc_status.launch.py
@@ -23,7 +23,7 @@ def generate_launch_description():
         parameters=[{
             "status": "STATUS_1",
             "motor": "BACK_RIGHT",
-            "namespace": "rear_right",
+            "namespace": "/drive/rear_right",
             "status_rate": 15,
             "logging": False
         }]
@@ -37,7 +37,7 @@ def generate_launch_description():
         parameters=[{
             "status": "STATUS_1",
             "motor": "FRONT_RIGHT",
-            "namespace": "front_right",
+            "namespace": "/drive/front_right",
             "status_rate": 15,
             "logging": False
         }]
@@ -51,7 +51,7 @@ def generate_launch_description():
         parameters=[{
             "status": "STATUS_1",
             "motor": "FRONT_LEFT",
-            "namespace": "front_left",
+            "namespace": "/drive/front_left",
             "status_rate": 15,
             "logging": False
         }]
@@ -65,7 +65,7 @@ def generate_launch_description():
         parameters=[{
             "status": "STATUS_1",
             "motor": "BACK_LEFT",
-            "namespace": "rear_left",
+            "namespace": "/drive/rear_left",
             "status_rate": 15,
             "logging": False
         }]

--- a/ros_ws/src/rad_control/launch/rad_status_main.launch.py
+++ b/ros_ws/src/rad_control/launch/rad_status_main.launch.py
@@ -7,6 +7,7 @@ def generate_launch_description():
         package="spidercan",
         executable="reader.py",
         name="rad1_reader",
+        namespace="drive",
         parameters=[{
             "topic": "/can/status/rad_can_in",
             "channel": "can0",
@@ -20,6 +21,7 @@ def generate_launch_description():
         package="spidercan",
         executable="reader.py",
         name="rad2_reader",
+        namespace="drive",
         parameters=[{
             "topic": "/can/config/rad_can_in",
             "channel": "can0",
@@ -32,6 +34,7 @@ def generate_launch_description():
         package="rad_control",
         executable="rad_status",
         name="rad_status_node",
+        namespace="drive",
         parameters=[{
             "can_topic": "/can/status/rad_can_in",
             "status_rate": 15

--- a/ros_ws/src/rad_control/launch/rad_status_main.launch.py
+++ b/ros_ws/src/rad_control/launch/rad_status_main.launch.py
@@ -2,10 +2,10 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 
 rad_status_to_id = {
-    "/front_right/rad_status": 0x11,
-    "/front_left/rad_status": 0x12,
-    "/rear_left/rad_status": 0x13,
-    "/rear_right/rad_status": 0x14
+    "/drive/front_right/rad_status": 0x11,
+    "/drive/front_left/rad_status": 0x12,
+    "/drive/rear_left/rad_status": 0x13,
+    "/drive/rear_right/rad_status": 0x14
 }
 
 def generate_launch_description():

--- a/ros_ws/src/rad_control/src/rad_drive_controller.cpp
+++ b/ros_ws/src/rad_control/src/rad_drive_controller.cpp
@@ -16,7 +16,7 @@ RAD_Drive_Controller::RAD_Drive_Controller() :
   can_pub_ = this->create_publisher<CANraw>("/can/can_out", 10);
 
   sub_ = this->create_subscription<SwerveModulesList>(
-    "/modules_command", 10, std::bind(&RAD_Drive_Controller::_callback, this, _1)
+    "/drive/modules_command", 10, std::bind(&RAD_Drive_Controller::_callback, this, _1)
   );
 
   rad_fl_drive.set_pid_angle_offset(120.0);

--- a/ros_ws/src/rad_control/src/rad_status.cpp
+++ b/ros_ws/src/rad_control/src/rad_status.cpp
@@ -5,7 +5,7 @@ RAD_Status::RAD_Status() : Node("rad_status_node")
   this->declare_parameter("can_topic", "/can/status/rad_can_in");
   this->declare_parameter("status_rate", 10);
   this->declare_parameter<std::vector<int64_t>>("rad_ids", {RAD__DRIVE__FRONT_LEFT, RAD__DRIVE__FRONT_RIGHT});
-  this->declare_parameter<std::vector<std::string>>("rad_status", {"/front_left/rad_status", "/front_right/rad_status"});
+  this->declare_parameter<std::vector<std::string>>("rad_status", {"/drive/front_left/rad_status", "/drive/front_right/rad_status"});
 
   rate = this->get_parameter("status_rate").as_int();
   topic = this->get_parameter("can_topic").as_string();

--- a/ros_ws/src/rad_control/src/rover_steer_pos.cpp
+++ b/ros_ws/src/rad_control/src/rover_steer_pos.cpp
@@ -18,7 +18,7 @@ SteerPos::SteerPos(std::string name) : Node(name),
 
     can_pub_ = this->create_publisher<CANraw>("/can/can_out", 10);
     sub_ = this->create_subscription<SwerveModulePulse>(
-        "/rad_pulses_repeat", 10, std::bind(&SteerPos::_pulse_callback, this, _1)
+        "/drive/rad_pulses_repeat", 10, std::bind(&SteerPos::_pulse_callback, this, _1)
     );
 }
 


### PR DESCRIPTION
- Correct Rover dimensions in kinematics model
- Add node and topic namespaces to all drive-related nodes (`/drive/`)