### PR TITLE
feat: implement C++ rover state manager node with mock timer

### DIFF
--- a/ros_ws/src/rover_state_manager/CMakeLists.txt
+++ b/ros_ws/src/rover_state_manager/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.8)
+project(rover_state_manager)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()
+
+
+
+add_executable(state_manager_node src/state_manager_node.cpp)
+ament_target_dependencies(state_manager_node rclcpp std_msgs)
+
+install(TARGETS
+  state_manager_node
+  DESTINATION lib/${PROJECT_NAME}
+)

--- a/ros_ws/src/rover_state_manager/package.xml
+++ b/ros_ws/src/rover_state_manager/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rover_state_manager</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="gobind2975@gmail.com">gobind</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros_ws/src/rover_state_manager/src/state_manager_node.cpp
+++ b/ros_ws/src/rover_state_manager/src/state_manager_node.cpp
@@ -1,0 +1,48 @@
+#include <chrono>
+#include <memory>
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/int32.hpp"
+
+using namespace std::chrono_literals;
+
+class RoverStateManager : public rclcpp::Node {
+public:
+  RoverStateManager() : Node("rover_state_manager") {
+    // 1. Create the Publisher targeting the Teensy's LED topic
+    publisher_ = this->create_publisher<std_msgs::msg::Int32>("/obc/rover_led_state", 10);
+
+    // 2. Create a timer to cycle states for testing (fires every 2 seconds)
+    timer_ = this->create_wall_timer(
+      2000ms, std::bind(&RoverStateManager::test_state_callback, this));
+
+    RCLCPP_INFO(this->get_logger(), "Rover State Manager initialized. Broadcasting to Teensy...");
+  }
+
+private:
+  void test_state_callback() {
+    auto message = std_msgs::msg::Int32();
+    
+    // Cycle through states: 1 (Auto/Red), 2 (Teleop/Blue), 3 (Arrived/Green)
+    static int current_state = 1;
+    message.data = current_state;
+    
+    RCLCPP_INFO(this->get_logger(), "Publishing LED State: %d", message.data);
+    publisher_->publish(message);
+
+    // Increment state for the next timer loop
+    current_state++;
+    if (current_state > 3) {
+      current_state = 1;
+    }
+  }
+
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+int main(int argc, char * argv[]) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<RoverStateManager>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
Implemented a new ROS 2 C++ publisher node (rover_state_manager). High-level brain for the rover's LED states. This node handles the logic of determining the rover's current operation mode and communicates directly with the Teensy 4.1S microcontroller over the micro-ROS bridge.